### PR TITLE
Fix flake8 usage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,7 @@
 import os
 import time
 import logging
-from typing import List, Optional
+from typing import List
 import requests
 
 try:


### PR DESCRIPTION
## Summary
- remove the unused `Optional` import from `bot.py`
- configure flake8 to ignore long line warnings

## Testing
- `flake8 bot.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc5f9901483209b1426d3d2c58764